### PR TITLE
Make user specify products

### DIFF
--- a/examples/link_token_create.rs
+++ b/examples/link_token_create.rs
@@ -9,6 +9,7 @@ async fn main() {
         client_name: "your client name",
         country_codes: &["your country codes"],
         language: "your language",
+        products: &["auth"],
         user: LinkTokenCreateRequestUser {
             address: Some(UserAddress {
                 city: "your city".to_owned(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1745,7 +1745,7 @@ See endpoint docs at <https://plaid.com/docs/api/tokens/#linktokencreate>.*/
             language: args.language.to_owned(),
             link_customization_name: None,
             payment_initiation: None,
-            products: None,
+            products: args.products.iter().map(|&x| x.to_owned()).collect(),
             redirect_uri: None,
             transfer: None,
             update: None,

--- a/src/request/link_token_create.rs
+++ b/src/request/link_token_create.rs
@@ -25,7 +25,7 @@ pub struct LinkTokenCreateRequest<'a> {
     pub language: String,
     pub link_customization_name: Option<String>,
     pub payment_initiation: Option<LinkTokenCreateRequestPaymentInitiation>,
-    pub products: Option<Vec<String>>,
+    pub products: Vec<String>,
     pub redirect_uri: Option<String>,
     pub transfer: Option<LinkTokenCreateRequestTransfer>,
     pub update: Option<LinkTokenCreateRequestUpdate>,
@@ -84,9 +84,8 @@ impl<'a> LinkTokenCreateRequest<'a> {
         if let Some(ref unwrapped) = self.payment_initiation {
             r = r.json(json!({ "payment_initiation" : unwrapped }));
         }
-        if let Some(ref unwrapped) = self.products {
-            r = r.json(json!({ "products" : unwrapped }));
-        }
+        
+        r = r.json(json!({ "products" : self.products }));
         if let Some(ref unwrapped) = self.redirect_uri {
             r = r.json(json!({ "redirect_uri" : unwrapped }));
         }
@@ -196,9 +195,8 @@ impl<'a> LinkTokenCreateRequest<'a> {
         products: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Self {
         self
-            .products = Some(
-            products.into_iter().map(|s| s.as_ref().to_owned()).collect(),
-        );
+            .products =
+            products.into_iter().map(|s| s.as_ref().to_owned()).collect();
         self
     }
     pub fn redirect_uri(mut self, redirect_uri: &str) -> Self {
@@ -227,6 +225,7 @@ pub struct LinkTokenCreateRequired<'a> {
     pub country_codes: &'a [&'a str],
     pub language: &'a str,
     pub user: LinkTokenCreateRequestUser,
+    pub products: &'a [&'a str]
 }
 impl<'a> LinkTokenCreateRequired<'a> {}
 impl<'a> ::std::future::IntoFuture for LinkTokenCreateRequest<'a> {


### PR DESCRIPTION
Creating a Plaid Link token requires products, so it should be a part of the required struct. This also updates the example.
This addresses https://github.com/libninjacom/plaid-rs/issues/8